### PR TITLE
add priority

### DIFF
--- a/src/priority/dto/create-priority.dto.ts
+++ b/src/priority/dto/create-priority.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose } from 'class-transformer';
+import { IsString, Length } from 'class-validator';
+
+@Exclude()
+export class CreatePriorityDto {
+  @Expose()
+  @Length(1, 64)
+  @IsString()
+  @ApiProperty({ default: 'High' })
+  name: string;
+}

--- a/src/priority/dto/pagination/priorities.pagination.dto.ts
+++ b/src/priority/dto/pagination/priorities.pagination.dto.ts
@@ -1,0 +1,6 @@
+import { BasePaginationDto } from 'src/common/pagination/dto/base.pagination.dto';
+import { PriorityDto } from '../priority.dto';
+
+export class PrioritiesPaginationDto extends BasePaginationDto<PriorityDto> {
+  items: PriorityDto[];
+}

--- a/src/priority/dto/pagination/priorities.pagination.options.dto.ts
+++ b/src/priority/dto/pagination/priorities.pagination.options.dto.ts
@@ -1,0 +1,3 @@
+import { BasePaginationOptionsDto } from 'src/common/pagination/dto/base.pagination.options.dto';
+
+export class PrioritiesPaginationOptionsDto extends BasePaginationOptionsDto {}

--- a/src/priority/dto/priority.dto.ts
+++ b/src/priority/dto/priority.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose } from 'class-transformer';
+
+@Exclude()
+export class PriorityDto {
+  @Expose()
+  @ApiProperty()
+  id: string;
+
+  @Expose()
+  @ApiProperty()
+  name: string;
+}

--- a/src/priority/dto/update-priority.dto.ts
+++ b/src/priority/dto/update-priority.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreatePriorityDto } from './create-priority.dto';
+
+export class UpdatePriorityDto extends PartialType(CreatePriorityDto) {}

--- a/src/priority/priority.controller.ts
+++ b/src/priority/priority.controller.ts
@@ -1,0 +1,81 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiConsumes, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { IsAdminGuard } from 'src/auth/guards/is-admin.guard';
+import { PriorityService } from './priority.service';
+import { plainToInstance } from 'class-transformer';
+import { PriorityDto } from './dto/priority.dto';
+import { CreatePriorityDto } from './dto/create-priority.dto';
+import { UpdatePriorityDto } from './dto/update-priority.dto';
+import { PrioritiesPaginationOptionsDto } from './dto/pagination/priorities.pagination.options.dto';
+import { PrioritiesPaginationDto } from './dto/pagination/priorities.pagination.dto';
+
+@Controller('priority')
+@ApiBearerAuth()
+@ApiTags('priority')
+export class PriorityController {
+  constructor(private readonly priorityService: PriorityService) {}
+
+  @ApiConsumes('application/x-www-form-urlencoded')
+  @Post('pagination')
+  @UseGuards(JwtAuthGuard)
+  async getPriorities(@Body() options: PrioritiesPaginationOptionsDto) {
+    const priorities = await this.priorityService.getPriorities(options);
+    return plainToInstance(PrioritiesPaginationDto, priorities, {
+      excludeExtraneousValues: true,
+    });
+  }
+
+  @ApiConsumes('application/x-www-form-urlencoded')
+  @Get(':priorityId')
+  @UseGuards(JwtAuthGuard)
+  async getPriority(@Param('priorityId', ParseUUIDPipe) priorityId: string) {
+    const priority = await this.priorityService.getPriorityById(priorityId);
+    return plainToInstance(PriorityDto, priority, {
+      excludeExtraneousValues: true,
+    });
+  }
+
+  @ApiConsumes('application/x-www-form-urlencoded')
+  @Delete(':priorityId')
+  @UseGuards(JwtAuthGuard, IsAdminGuard)
+  async deletePriority(@Param('priorityId', ParseUUIDPipe) priorityId: string) {
+    const priority = await this.priorityService.deletePriorityById(priorityId);
+    return plainToInstance(PriorityDto, priority, {
+      excludeExtraneousValues: true,
+    });
+  }
+
+  @ApiConsumes('application/x-www-form-urlencoded')
+  @Patch(':priorityId')
+  @UseGuards(JwtAuthGuard, IsAdminGuard)
+  async updatePriority(
+    @Body() dto: UpdatePriorityDto,
+    @Param('priorityId', ParseUUIDPipe) priorityId: string,
+  ) {
+    const priority = await this.priorityService.updatePriorityById(priorityId, dto);
+    return plainToInstance(PriorityDto, priority, {
+      excludeExtraneousValues: true,
+    });
+  }
+
+  @ApiConsumes('application/x-www-form-urlencoded')
+  @Post()
+  @UseGuards(JwtAuthGuard, IsAdminGuard)
+  async createPriority(@Body() dto: CreatePriorityDto) {
+    const priority = await this.priorityService.createPriority(dto);
+    return plainToInstance(PriorityDto, priority, {
+      excludeExtraneousValues: true,
+    });
+  }
+}

--- a/src/priority/priority.module.ts
+++ b/src/priority/priority.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PriorityController } from './priority.controller';
+import { PriorityService } from './priority.service';
+
+@Module({
+  controllers: [PriorityController],
+  providers: [PriorityService],
+  exports: [PriorityService],
+})
+export class PriorityModule {}

--- a/src/priority/priority.service.ts
+++ b/src/priority/priority.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { CreatePriorityDto } from './dto/create-priority.dto';
+import { UpdatePriorityDto } from './dto/update-priority.dto';
+import { PrioritiesPaginationOptionsDto } from './dto/pagination/priorities.pagination.options.dto';
+
+@Injectable()
+export class PriorityService {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async getPriorityById(id: string) {
+    return this.prismaService.priority.findUniqueOrThrow({ where: { id } });
+  }
+
+  async createPriority(data: CreatePriorityDto) {
+    return this.prismaService.priority.create({ data });
+  }
+
+  async updatePriorityById(id: string, data: UpdatePriorityDto) {
+    return this.prismaService.priority.update({ 
+      where: { id }, 
+      data 
+    });
+  }
+
+  async deletePriorityById(id: string) {
+    return this.prismaService.priority.delete({ where: { id } });
+  }
+
+  async getPriorities(options: PrioritiesPaginationOptionsDto) {
+    const items = await this.prismaService.priority.findMany({
+      take: options.perPage,
+      skip: options.perPage * (options.page - 1),
+    });
+
+    const count = await this.prismaService.priority.count();
+
+    return {
+      items,
+      meta: {
+        page: options.page,
+        perPage: items.length,
+        totalPages: Math.ceil(count / options.perPage),
+        total: count,
+      },
+    };
+  }
+}


### PR DESCRIPTION
### What’s new

Added **PriorityModule** with CRUD + pagination
Wired controller, service, DTOs, and guards
Integrated with PrismaService
Swagger docs for all endpoints

### Endpoints

**Priorities**

* `POST /priority/pagination` → list with meta
* `GET /priority/:id` → get by id
* `POST /priority` → create *(admin)*
* `PATCH /priority/:id` → update *(admin)*
* `DELETE /priority/:id` → delete *(admin)*

**Access:**

* user → list, get by id
* admin → all

**DTOs:**
CreatePriorityDto, UpdatePriorityDto, PriorityDto, Pagination options/results

### Notes

* All endpoints consume `application/x-www-form-urlencoded`
* `JwtAuthGuard` required everywhere
* `IsAdminGuard` for create/update/delete
* Requires `Priority` model in Prisma schema

### Next steps

* Add tests for CRUD and guards
* Seed default priorities (Low / Medium / High)
* Verify Swagger shows DTOs and endpoints
